### PR TITLE
Add inmemory broker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _testmain.go
 *.pyc
 
 coverage.out
+.idea

--- a/backend_test.go
+++ b/backend_test.go
@@ -12,6 +12,7 @@ func getBackends() []CeleryBackend {
 	return []CeleryBackend{
 		NewRedisCeleryBackend("redis://localhost:6379"),
 		NewAMQPCeleryBackend("amqp://"),
+		NewInMemoryBackend(),
 	}
 }
 

--- a/broker_test.go
+++ b/broker_test.go
@@ -23,6 +23,7 @@ func getBrokers() []CeleryBroker {
 	return []CeleryBroker{
 		NewRedisCeleryBroker("redis://localhost:6379"),
 		//NewAMQPCeleryBroker("amqp://"),
+		NewInMemoryBroker(),
 	}
 }
 

--- a/gocelery_test.go
+++ b/gocelery_test.go
@@ -58,9 +58,9 @@ func getRedisClient() (*CeleryClient, error) {
 }
 
 func getInMemoryClient() (*CeleryClient, error) {
-	redisBroker := NewInMemoryBroker()
-	redisBackend := NewInMemoryBackend()
-	return NewCeleryClient(redisBroker, redisBackend, 1)
+	inMemoryBroker := NewInMemoryBroker()
+	inMemoryBackend := NewInMemoryBackend()
+	return NewCeleryClient(inMemoryBroker, inMemoryBackend, 1)
 }
 
 func getClients() ([]*CeleryClient, error) {

--- a/gocelery_test.go
+++ b/gocelery_test.go
@@ -64,22 +64,22 @@ func getInMemoryClient() (*CeleryClient, error) {
 }
 
 func getClients() ([]*CeleryClient, error) {
-	//redisClient, err := getRedisClient()
-	//if err != nil {
-	//	return nil, err
-	//}
-	//amqpClient, err := getAMQPClient()
-	//if err != nil {
-	//	return nil, err
-	//}
+	redisClient, err := getRedisClient()
+	if err != nil {
+		return nil, err
+	}
+	amqpClient, err := getAMQPClient()
+	if err != nil {
+		return nil, err
+	}
 	inMemoryClient, err := getInMemoryClient()
 	if err != nil {
 		return nil, err
 	}
 
 	return []*CeleryClient{
-		//redisClient,
-		//amqpClient,
+		redisClient,
+		amqpClient,
 		inMemoryClient,
 	}, nil
 }

--- a/gocelery_test.go
+++ b/gocelery_test.go
@@ -64,22 +64,22 @@ func getInMemoryClient() (*CeleryClient, error) {
 }
 
 func getClients() ([]*CeleryClient, error) {
-	redisClient, err := getRedisClient()
-	if err != nil {
-		return nil, err
-	}
-	amqpClient, err := getAMQPClient()
-	if err != nil {
-		return nil, err
-	}
+	//redisClient, err := getRedisClient()
+	//if err != nil {
+	//	return nil, err
+	//}
+	//amqpClient, err := getAMQPClient()
+	//if err != nil {
+	//	return nil, err
+	//}
 	inMemoryClient, err := getInMemoryClient()
 	if err != nil {
 		return nil, err
 	}
 
 	return []*CeleryClient{
-		redisClient,
-		amqpClient,
+		//redisClient,
+		//amqpClient,
 		inMemoryClient,
 	}, nil
 }
@@ -146,7 +146,7 @@ func TestWorkerClient(t *testing.T) {
 				}
 
 				debugLog(celeryClient, "validating result")
-				actual := int(kwargVal.(float64))
+				actual := int(kwargVal.(int))
 				if actual != expected {
 					t.Errorf("returned result %v is different from expected value %v", actual, expected)
 					return
@@ -160,7 +160,7 @@ func TestWorkerClient(t *testing.T) {
 				}
 
 				debugLog(celeryClient, "validating result")
-				actual = int(argVal.(float64))
+				actual = int(argVal.(int64))
 				if actual != expected {
 					t.Errorf("returned result %v is different from expected value %v", actual, expected)
 					return

--- a/gocelery_test.go
+++ b/gocelery_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 	"time"
-)
+	)
 
 func multiply(a int, b int) int {
 	return a * b
@@ -146,7 +146,7 @@ func TestWorkerClient(t *testing.T) {
 				}
 
 				debugLog(celeryClient, "validating result")
-				actual := int(kwargVal.(int))
+				actual := convertInterface(kwargVal)
 				if actual != expected {
 					t.Errorf("returned result %v is different from expected value %v", actual, expected)
 					return
@@ -160,7 +160,7 @@ func TestWorkerClient(t *testing.T) {
 				}
 
 				debugLog(celeryClient, "validating result")
-				actual = int(argVal.(int64))
+				actual = convertInterface(argVal)
 				if actual != expected {
 					t.Errorf("returned result %v is different from expected value %v", actual, expected)
 					return
@@ -225,3 +225,15 @@ func TestBlockingGet(t *testing.T) {
 	}
 }
 */
+
+func convertInterface(val interface{}) int {
+	f, ok := val.(float64)
+	if ok {
+		return int(f)
+	}
+	i, ok := val.(int64)
+	if ok {
+		return int(i)
+	}
+	return val.(int)
+}

--- a/gocelery_test.go
+++ b/gocelery_test.go
@@ -57,6 +57,12 @@ func getRedisClient() (*CeleryClient, error) {
 	return NewCeleryClient(redisBroker, redisBackend, 1)
 }
 
+func getInMemoryClient() (*CeleryClient, error) {
+	redisBroker := NewInMemoryBroker()
+	redisBackend := NewInMemoryBackend()
+	return NewCeleryClient(redisBroker, redisBackend, 1)
+}
+
 func getClients() ([]*CeleryClient, error) {
 	redisClient, err := getRedisClient()
 	if err != nil {
@@ -66,9 +72,15 @@ func getClients() ([]*CeleryClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	inMemoryClient, err := getInMemoryClient()
+	if err != nil {
+		return nil, err
+	}
+
 	return []*CeleryClient{
 		redisClient,
 		amqpClient,
+		inMemoryClient,
 	}, nil
 }
 

--- a/inmemory_backend.go
+++ b/inmemory_backend.go
@@ -1,0 +1,31 @@
+package gocelery
+
+// Error represents an error returned from in memory backend.
+type Error string
+
+func (err Error) Error() string {
+	return string(err)
+}
+
+type InMemoryBackend struct{
+	ResultStore map[string]*ResultMessage
+}
+
+func NewInMemoryBackend() *InMemoryBackend {
+	return &InMemoryBackend{make(map[string]*ResultMessage)}
+}
+
+func (b *InMemoryBackend) GetResult(taskID string) (*ResultMessage, error) {
+	if res, ok := b.ResultStore[taskID]; ok {
+		return res, nil
+	}
+	var err Error = "task does not exist"
+	return nil, err
+}
+
+func (b *InMemoryBackend) SetResult(taskID string, result *ResultMessage) error {
+	b.ResultStore[taskID] = result
+	return nil
+}
+
+

--- a/inmemory_backend.go
+++ b/inmemory_backend.go
@@ -1,11 +1,6 @@
 package gocelery
 
-// Error represents an error returned from in memory backend.
-type Error string
-
-func (err Error) Error() string {
-	return string(err)
-}
+import "errors"
 
 type InMemoryBackend struct{
 	ResultStore map[string]*ResultMessage
@@ -19,8 +14,7 @@ func (b *InMemoryBackend) GetResult(taskID string) (*ResultMessage, error) {
 	if res, ok := b.ResultStore[taskID]; ok {
 		return res, nil
 	}
-	var err Error = "task does not exist"
-	return nil, err
+	return nil, errors.New("task does not exist")
 }
 
 func (b *InMemoryBackend) SetResult(taskID string, result *ResultMessage) error {
@@ -28,4 +22,6 @@ func (b *InMemoryBackend) SetResult(taskID string, result *ResultMessage) error 
 	return nil
 }
 
-
+func (b *InMemoryBackend) Clear() {
+	b.ResultStore = make(map[string]*ResultMessage)
+}

--- a/inmemory_backend.go
+++ b/inmemory_backend.go
@@ -2,7 +2,7 @@ package gocelery
 
 import "errors"
 
-type InMemoryBackend struct{
+type InMemoryBackend struct {
 	ResultStore map[string]*ResultMessage
 }
 

--- a/inmemory_backend.go
+++ b/inmemory_backend.go
@@ -1,16 +1,22 @@
 package gocelery
 
-import "errors"
+import (
+	"errors"
+	"sync"
+)
 
 type InMemoryBackend struct {
 	ResultStore map[string]*ResultMessage
+	lock sync.RWMutex
 }
 
 func NewInMemoryBackend() *InMemoryBackend {
-	return &InMemoryBackend{make(map[string]*ResultMessage)}
+	return &InMemoryBackend{make(map[string]*ResultMessage), sync.RWMutex{}}
 }
 
 func (b *InMemoryBackend) GetResult(taskID string) (*ResultMessage, error) {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
 	if res, ok := b.ResultStore[taskID]; ok {
 		return res, nil
 	}
@@ -18,7 +24,9 @@ func (b *InMemoryBackend) GetResult(taskID string) (*ResultMessage, error) {
 }
 
 func (b *InMemoryBackend) SetResult(taskID string, result *ResultMessage) error {
+	b.lock.Lock()
 	b.ResultStore[taskID] = result
+	b.lock.Unlock()
 	return nil
 }
 

--- a/inmemory_broker.go
+++ b/inmemory_broker.go
@@ -1,0 +1,22 @@
+package gocelery
+
+type InMemoryBroker struct{
+	taskQueue []*TaskMessage
+}
+
+func NewInMemoryBroker() *InMemoryBroker {
+	return &InMemoryBroker{make([]*TaskMessage, 0)}
+}
+
+func (b *InMemoryBroker) SendCeleryMessage(m *CeleryMessage) error {
+	b.taskQueue = append(b.taskQueue, m.GetTaskMessage())
+	return nil
+}
+
+func (b *InMemoryBroker) GetTaskMessage() (t *TaskMessage, e error) {
+	if len(b.taskQueue) == 0 {
+		return nil, nil
+	}
+	t, b.taskQueue = b.taskQueue[0], b.taskQueue[1:]
+	return t, nil
+}

--- a/inmemory_broker.go
+++ b/inmemory_broker.go
@@ -20,3 +20,8 @@ func (b *InMemoryBroker) GetTaskMessage() (t *TaskMessage, e error) {
 	t, b.taskQueue = b.taskQueue[0], b.taskQueue[1:]
 	return t, nil
 }
+
+func (b *InMemoryBroker) Clear(m *CeleryMessage) error {
+	b.taskQueue = make([]*TaskMessage, 0)
+	return nil
+}

--- a/inmemory_broker.go
+++ b/inmemory_broker.go
@@ -1,6 +1,6 @@
 package gocelery
 
-type InMemoryBroker struct{
+type InMemoryBroker struct {
 	taskQueue []*TaskMessage
 }
 

--- a/worker.go
+++ b/worker.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"reflect"
 	"sync"
-)
+	)
 
 // CeleryWorker represents distributed task worker
 type CeleryWorker struct {

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,11 +1,11 @@
 package gocelery
 
 import (
+	"errors"
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
-	"errors"
-	"fmt"
 )
 
 // add is test task method
@@ -32,7 +32,7 @@ func newInMemoryCeleryWorker(numWorkers int) *CeleryWorker {
 func getWorkers(numWorkers int) []*CeleryWorker {
 	return []*CeleryWorker{
 		newCeleryWorker(numWorkers),
-		//newInMemoryCeleryWorker(numWorkers),
+		newInMemoryCeleryWorker(numWorkers),
 	}
 }
 
@@ -44,7 +44,7 @@ func registerTask(celeryWorker *CeleryWorker) string {
 	return taskName
 }
 
-func runTestForEachWorker(testFunc func (celeryWorker *CeleryWorker, numWorkers int) error, numWorkers int, t *testing.T) {
+func runTestForEachWorker(testFunc func(celeryWorker *CeleryWorker, numWorkers int) error, numWorkers int, t *testing.T) {
 	for _, worker := range getWorkers(numWorkers) {
 		err := testFunc(worker, numWorkers)
 		if err != nil {
@@ -63,7 +63,7 @@ func registerTaskTest(celeryWorker *CeleryWorker, numWorkers int) error {
 	if receivedTask == nil {
 		return errors.New("failed to retrieve task")
 	}
-	return  nil
+	return nil
 }
 
 func TestRunTask(t *testing.T) {


### PR DESCRIPTION
This first PR adds support for an in memory broker/backend to enable testing without any external queue server dependancies.

I also refactored the tests a little bit so that the tests can be run for all backends/brokers when needed.