### PR TITLE
Remove non threadsafe

### DIFF
--- a/example/worker/main.go
+++ b/example/worker/main.go
@@ -64,8 +64,8 @@ func main() {
 	celeryClient.Register("worker.add", add)
 	celeryClient.Register("worker.add_reflect", &AddTask{})
 
-	// Start Worker - blocking method
-	go celeryClient.StartWorker()
+	// Start Worker - non blocking method
+	celeryClient.StartWorker()
 	// Wait 30 seconds and stop all workers
 	time.Sleep(30 * time.Second)
 	celeryClient.StopWorker()

--- a/worker.go
+++ b/worker.go
@@ -7,7 +7,8 @@ import (
 	"sync"
 )
 
-// CeleryWorker represents distributed task worker
+// CeleryWorker represents distributed task worker.
+// Not thread safe. Shouldn't be used from within multiple go routines.
 type CeleryWorker struct {
 	broker          CeleryBroker
 	backend         CeleryBackend

--- a/worker_test.go
+++ b/worker_test.go
@@ -84,7 +84,7 @@ func TestStartStop(t *testing.T) {
 	numWorkers := rand.Intn(10)
 	celeryWorker := newCeleryWorker(numWorkers)
 	_ = registerTask(celeryWorker)
-	go celeryWorker.StartWorker()
+	celeryWorker.StartWorker()
 	time.Sleep(100 * time.Millisecond)
 	celeryWorker.StopWorker()
 }


### PR DESCRIPTION
I notice that when running tests with `-race` flag there is a warning issued against `startWorker` and `stopWorker` functions. This pr fixes those issues.

```
=== RUN   TestRegisterTask
--- PASS: TestRegisterTask (0.00s)
=== RUN   TestRunTask
--- PASS: TestRunTask (0.00s)
=== RUN   TestNumWorkers
--- PASS: TestNumWorkers (0.00s)
=== RUN   TestStartStop
==================
WARNING: DATA RACE
Read at 0x00c4200b8408 by goroutine 9:
  github.com/gocelery/gocelery.(*CeleryWorker).StopWorker()
      /Users/vimukthi/projects/go/src/github.com/gocelery/gocelery/worker.go:77 +0x3f
  github.com/gocelery/gocelery.TestStartStop()
      /Users/vimukthi/projects/go/src/github.com/gocelery/gocelery/worker_test.go:89 +0x99
  testing.tRunner()
      /Users/vimukthi/software/go/go1.10.3/src/testing/testing.go:777 +0x16d

Previous write at 0x00c4200b8408 by goroutine 10:
  github.com/gocelery/gocelery.(*CeleryWorker).StartWorker()
      /Users/vimukthi/projects/go/src/github.com/gocelery/gocelery/worker.go:34 +0x68

Goroutine 9 (running) created at:
  testing.(*T).Run()
      /Users/vimukthi/software/go/go1.10.3/src/testing/testing.go:824 +0x564
  testing.runTests.func1()
      /Users/vimukthi/software/go/go1.10.3/src/testing/testing.go:1063 +0xa4
  testing.tRunner()
      /Users/vimukthi/software/go/go1.10.3/src/testing/testing.go:777 +0x16d
  testing.runTests()
      /Users/vimukthi/software/go/go1.10.3/src/testing/testing.go:1061 +0x4e1
  testing.(*M).Run()
      /Users/vimukthi/software/go/go1.10.3/src/testing/testing.go:978 +0x2cd
  main.main()
      _testmain.go:64 +0x22a

Goroutine 10 (finished) created at:
  github.com/gocelery/gocelery.TestStartStop()
      /Users/vimukthi/projects/go/src/github.com/gocelery/gocelery/worker_test.go:87 +0x7e
  testing.tRunner()
      /Users/vimukthi/software/go/go1.10.3/src/testing/testing.go:777 +0x16d
==================
--- FAIL: TestStartStop (1.94s)
	testing.go:730: race detected during execution of test
FAIL

Process finished with exit code 1
```