### PR TITLE
Add a Copy method to CeleryTask to prevent race conditions or corruption of tasks

### DIFF
--- a/gocelery.go
+++ b/gocelery.go
@@ -86,6 +86,10 @@ func (cc *CeleryClient) delay(task *TaskMessage) (*AsyncResult, error) {
 // ResultMessage must be obtained using GetResultMessage()
 type CeleryTask interface {
 
+	// Copy - is used to safely create and execute a copy of a task (stateful)
+	// in a worker when there are multiple workers working on the same type of task but with different internal state.
+	Copy() (CeleryTask, error)
+
 	// ParseKwargs - define a method to parse kwargs
 	ParseKwargs(map[string]interface{}) error
 

--- a/gocelery_test.go
+++ b/gocelery_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 	"time"
-	)
+)
 
 func multiply(a int, b int) int {
 	return a * b
@@ -16,6 +16,10 @@ func multiply(a int, b int) int {
 type multiplyKwargs struct {
 	a int
 	b int
+}
+
+func (m *multiplyKwargs) Copy() (CeleryTask, error) {
+	return &multiplyKwargs{m.a, m.b}, nil
 }
 
 func (m *multiplyKwargs) ParseKwargs(kwargs map[string]interface{}) error {

--- a/gocelery_test.go
+++ b/gocelery_test.go
@@ -1,13 +1,13 @@
 package gocelery
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
 	"reflect"
 	"testing"
 	"time"
-	"errors"
 )
 
 func multiply(a int, b int) int {
@@ -50,17 +50,17 @@ func (m *multiplyKwargs) RunTask() (interface{}, error) {
 	return result, nil
 }
 
-type stateFulTask struct{
+type stateFulTask struct {
 	copyerror bool
-	state map[string]interface{}
+	state     map[string]interface{}
 }
 
 func (st *stateFulTask) Copy() (CeleryTask, error) {
-	if (st.copyerror) {
+	if st.copyerror {
 		return nil, errors.New("dummy copying error")
 	}
 	newState := make(map[string]interface{})
-	for k,v := range st.state {
+	for k, v := range st.state {
 		newState[k] = v
 	}
 	return &stateFulTask{st.copyerror, newState}, nil

--- a/inmemory_backend.go
+++ b/inmemory_backend.go
@@ -7,7 +7,7 @@ import (
 
 type InMemoryBackend struct {
 	ResultStore map[string]*ResultMessage
-	lock sync.RWMutex
+	lock        sync.RWMutex
 }
 
 func NewInMemoryBackend() *InMemoryBackend {

--- a/inmemory_broker.go
+++ b/inmemory_broker.go
@@ -4,7 +4,7 @@ import "sync"
 
 type InMemoryBroker struct {
 	taskQueue []*TaskMessage
-	lock sync.RWMutex
+	lock      sync.RWMutex
 }
 
 func NewInMemoryBroker() *InMemoryBroker {
@@ -36,7 +36,7 @@ func (b *InMemoryBroker) Clear() error {
 	return nil
 }
 
-func (b *InMemoryBroker) isEmpty() (bool) {
+func (b *InMemoryBroker) isEmpty() bool {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 	return len(b.taskQueue) == 0

--- a/inmemory_test.go
+++ b/inmemory_test.go
@@ -1,16 +1,16 @@
 package gocelery
 
 import (
-	"testing"
 	"log"
+	"testing"
 	"time"
 )
 
 func TestInMemoryBroker_Concurrency(t *testing.T) {
 	tests := []struct {
-		name string
-		numMasters int
-		numWorkers int
+		name                 string
+		numMasters           int
+		numWorkers           int
 		numMessagesPerMaster int
 	}{
 		{"singleMasterSingleWorker", 1, 1, 3},
@@ -82,7 +82,7 @@ func checkMessages(t *testing.T, resultChannel chan string, ids map[string]bool,
 func receiveMessages(ib *InMemoryBroker, resultChannel chan string) {
 	// wait for messages to become available from masters, otherwise the workers will exit too early
 	time.Sleep(10 * time.Millisecond)
-	for ; !ib.isEmpty(); {
+	for !ib.isEmpty() {
 		msg, err := ib.GetTaskMessage()
 		if err != nil {
 			log.Fatal(err)

--- a/worker.go
+++ b/worker.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"reflect"
 	"sync"
-	)
+)
 
 // CeleryWorker represents distributed task worker.
 // Not thread safe. Shouldn't be used from within multiple go routines.
@@ -116,6 +116,11 @@ func (w *CeleryWorker) RunTask(message *TaskMessage) (*ResultMessage, error) {
 	// convert to task interface
 	taskInterface, ok := task.(CeleryTask)
 	if ok {
+		if taskInterfaceCpy, err := taskInterface.Copy(); err != nil {
+			return nil, err
+		} else {
+			taskInterface = taskInterfaceCpy
+		}
 		//log.Println("using task interface")
 		if err := taskInterface.ParseKwargs(message.Kwargs); err != nil {
 			return nil, err

--- a/worker.go
+++ b/worker.go
@@ -116,6 +116,7 @@ func (w *CeleryWorker) RunTask(message *TaskMessage) (*ResultMessage, error) {
 	// convert to task interface
 	taskInterface, ok := task.(CeleryTask)
 	if ok {
+		// copy the task to avoid race conditions caused by task state
 		if taskInterfaceCpy, err := taskInterface.Copy(); err != nil {
 			return nil, err
 		} else {


### PR DESCRIPTION
Add a Copy method to CeleryTask to prevent race conditions or corruption of tasks